### PR TITLE
Augmented SoundCloud alert

### DIFF
--- a/mp3extractor.js
+++ b/mp3extractor.js
@@ -104,7 +104,7 @@ alert(function() {
     return "Copied audio tag to clipboard!";
   }
   if (isSoundCloud()) {
-    return "For SoundCloud you have to be on the page of the song itself. Can't determine the URL otherwise!";
+    return "For SoundCloud you have to be on the page of the song itself. Can't determine the URL otherwise! If you are on the song page and see this error, refresh and try again.";
   }
   return "Could not determine URL of MP3...";
 }());


### PR DESCRIPTION
In my tests, being on the song page in SoundCloud isn't always enough – it depends on the route by which I arrive on the song page and if I have played anything previously. So I've added a note that refreshing the song page may help, which it does in nearly every test I've run.